### PR TITLE
Remove git conflict markers from workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,8 +57,6 @@ jobs:
           - 14.3.0
           - 14.2.0
           - 14.1.0
-<<<<<<< Updated upstream
-=======
           - 13.14.0
           - 13.13.0
           - 13.12.0
@@ -76,7 +74,6 @@ jobs:
           - 13.1.0
           - 13.0.1
           - 13.0.0
->>>>>>> Stashed changes
     steps:
       - name: Setup nix features
         run: echo "experimental-features = nix-command flakes ca-references" > /etc/nix/nix.conf


### PR DESCRIPTION
Removes the conflict markers from a prior commit that would be showing errors in GitHub Actions.